### PR TITLE
Bug: Make possible to override LUA_32BITS as requested

### DIFF
--- a/luaconf.h
+++ b/luaconf.h
@@ -122,7 +122,9 @@
 /*
 @@ LUA_32BITS enables Lua with 32-bit integers and 32-bit floats.
 */
+#if !defined(LUA_32BITS)
 #define LUA_32BITS	0
+#endif
 
 
 /*


### PR DESCRIPTION
Make possible to override `LUA_32BITS`, Lua itself raises an error message saying to override `LUA_32BITS`, so redefining it unconditionally it is a bug.

```
lua/luaconf.h:125:9: warning: 'LUA_32BITS' macro redefined [-Wmacro-redefined]
  125 | #define LUA_32BITS      0
      |         ^
<command line>:9:9: note: previous definition is here
    9 | #define LUA_32BITS 1
      |         ^
In file included from lua/lapi.c:17:
In file included from lua/lua.h:16:
lua/luaconf.h:572:2: error: "Compiler does not support 'long long'. Use option '-DLUA_32BITS'   or '-DLUA_C89_NUMBERS' (see file 'luaconf.h' for details)"
  572 | #error "Compiler does not support 'long long'. Use option '-DLUA_32BITS' \
      |  ^
```